### PR TITLE
fix: call to global obj

### DIFF
--- a/Magritte/descriptions/MADescription.js
+++ b/Magritte/descriptions/MADescription.js
@@ -375,8 +375,8 @@ export class MADescription
 
   validate(model)
   {
-    visitor = this.validator;
-    errors = visitor.validateModelDescription(model, this);
+    const visitor = this.validator;
+    const errors = visitor.validateModelDescription(model, this);
     return errors;
   }
 


### PR DESCRIPTION
Fix MADescription.validate — undeclared variables

validate() used implicit global assignments instead of variable declarations:

```javascript:
// before
validate(model) {
  visitor = this.validator;
  errors = visitor.validateModelDescription(model, this);
  return errors;
}
```

Fix: added const declarations for both variables.